### PR TITLE
Option to return raw data (mesh, box) for Facemesh / "preserve aspect ratio" fix from Facemesh upstream

### DIFF
--- a/src/face/facemesh.js
+++ b/src/face/facemesh.js
@@ -17,7 +17,7 @@ class MediaPipeFaceMesh {
       if (prediction.isDisposedInternal) continue; // guard against disposed tensors on long running operations such as pause in middle of processing
       const mesh = prediction.coords ? prediction.coords.arraySync() : null;
 // AT: mesh_raw
-      const mesh_raw = prediction.rawCoords;
+      const meshRaw = prediction.rawCoords;
       const annotations = {};
       if (mesh && mesh.length > 0) {
         for (let key = 0; key < coords.MESH_ANNOTATIONS.length; key++) {
@@ -27,7 +27,7 @@ class MediaPipeFaceMesh {
         }
       }
 // AT: raw version of box, the same as the TFJS Facemesh output version (.boundingBox)
-      const box_raw = (config.face.mesh.requestRawData && prediction.box) ? {topLeft: prediction.box.startPoint, bottomRight: prediction.box.endPoint} : null;
+      const boxRaw = (config.face.mesh.returnRawData && prediction.box) ? {topLeft: prediction.box.startPoint, bottomRight: prediction.box.endPoint} : null;
 
       const box = prediction.box ? [
         Math.max(0, prediction.box.startPoint[0]),
@@ -40,9 +40,9 @@ class MediaPipeFaceMesh {
         confidence: prediction.confidence || 0,
         box,
         mesh,
-// AT: box_raw, mesh_raw
-        box_raw,
-        mesh_raw,
+// AT: boxRaw, meshRaw
+        boxRaw,
+        meshRaw,
         annotations,
         image: prediction.image ? tf.clone(prediction.image) : null,
       });

--- a/src/face/facemesh.js
+++ b/src/face/facemesh.js
@@ -16,6 +16,8 @@ class MediaPipeFaceMesh {
     for (const prediction of (predictions || [])) {
       if (prediction.isDisposedInternal) continue; // guard against disposed tensors on long running operations such as pause in middle of processing
       const mesh = prediction.coords ? prediction.coords.arraySync() : null;
+// AT: mesh_raw
+      const mesh_raw = prediction.rawCoords;
       const annotations = {};
       if (mesh && mesh.length > 0) {
         for (let key = 0; key < coords.MESH_ANNOTATIONS.length; key++) {
@@ -24,16 +26,23 @@ class MediaPipeFaceMesh {
           }
         }
       }
+// AT: raw version of box, the same as the TFJS Facemesh output version (.boundingBox)
+      const box_raw = (config.face.mesh.requestRawData && prediction.box) ? {topLeft: prediction.box.startPoint, bottomRight: prediction.box.endPoint} : null;
+
       const box = prediction.box ? [
         Math.max(0, prediction.box.startPoint[0]),
         Math.max(0, prediction.box.startPoint[1]),
         Math.min(input.shape[2], prediction.box.endPoint[0]) - prediction.box.startPoint[0],
         Math.min(input.shape[1], prediction.box.endPoint[1]) - prediction.box.startPoint[1],
       ] : 0;
+
       results.push({
         confidence: prediction.confidence || 0,
         box,
         mesh,
+// AT: box_raw, mesh_raw
+        box_raw,
+        mesh_raw,
         annotations,
         image: prediction.image ? tf.clone(prediction.image) : null,
       });

--- a/src/face/facepipeline.js
+++ b/src/face/facepipeline.js
@@ -244,13 +244,13 @@ class Pipeline {
       const transformedCoords = tf.tensor2d(transformedCoordsData);
       const prediction = {
         coords: transformedCoords,
-// AT: rawCoords
-        rawCoords: (config.face.mesh.requestRawData) ? rawCoords : null,
         box: landmarksBox,
         faceConfidence: confidenceVal,
         confidence: box.confidence,
         image: face,
       };
+// AT: rawCoords
+      if (config.face.mesh.returnRawData) prediction.rawCoords = rawCoords;
 // AT: preserve aspect ratio, pulled from Facemesh upstream
       this.storedBoxes[i] = { ...squarifiedLandmarksBox, landmarks: transformedCoords.arraySync(), confidence: box.confidence, faceConfidence: confidenceVal };
 //      this.storedBoxes[i] = { ...landmarksBox, landmarks: transformedCoords.arraySync(), confidence: box.confidence, faceConfidence: confidenceVal };

--- a/src/human.js
+++ b/src/human.js
@@ -291,9 +291,9 @@ class Human {
         confidence: face.confidence,
         box: face.box,
         mesh: face.mesh,
-// AT: box_raw, mesh_raw
-        box_raw: face.box_raw,
-        mesh_raw: face.mesh_raw,
+// AT: boxRaw, meshRaw
+        boxRaw: face.boxRaw,
+        meshRaw: face.meshRaw,
         annotations: face.annotations,
         age: ageRes.age,
         gender: genderRes.gender,

--- a/src/human.js
+++ b/src/human.js
@@ -291,6 +291,9 @@ class Human {
         confidence: face.confidence,
         box: face.box,
         mesh: face.mesh,
+// AT: box_raw, mesh_raw
+        box_raw: face.box_raw,
+        mesh_raw: face.mesh_raw,
         annotations: face.annotations,
         age: ageRes.age,
         gender: genderRes.gender,


### PR DESCRIPTION
In some use cases of Facemesh such as 3D calculations, one may need the raw data (such as mesh) as output, instead of the current version which has been mapped to fit the source image. With this pull request, a new boolean option "config.face.mesh.requestRawData" is now available (false by default), which allows additional outputs as raw data (.mesh_raw, .box_raw).

The second change refers to the "preserve aspect ratio" fix from `Facemesh` upstream.

https://github.com/tensorflow/tfjs-models/commit/85e6e487cc4bd21f0707a509e5024484a0798aa0

I am not really sure if this has been addressed in `human` already in some way, but judging from the source code it appears to be missing.