### PR TITLE
Fix and cleanup rotationMatrixToEulerAngle

### DIFF
--- a/src/faceall.ts
+++ b/src/faceall.ts
@@ -48,28 +48,17 @@ const calculateFaceAngle = (face, image_size): { pitch: number, yaw: number, row
     if (r10 < 1) {
       if (r10 > -1) {
         thetaZ = Math.asin(r10);
-        // thetaY = Math.atan2(-r20, r00);
+        thetaY = Math.atan2(-r20, r00);
         thetaX = Math.atan2(-r12, r11);
       } else {
         thetaZ = -pi / 2;
-        // thetaY = -Math.atan2(r21, r22);
+        thetaY = -Math.atan2(r21, r22);
         thetaX = 0;
       }
     } else {
       thetaZ = pi / 2;
-      // thetaY = Math.atan2(r21, r22);
+      thetaY = Math.atan2(r21, r22);
       thetaX = 0;
-    }
-
-    // compensate Y rotation (from XYZ rotation order routine) which is not accurate and too small in YZX calculation
-    if (r02 < 1) {
-      if (r02 > -1) {
-        thetaY = Math.asin(r02);
-      } else {
-        thetaY = -pi / 2;
-      }
-    } else {
-      thetaY = pi / 2;
     }
 
     // pitch, yaw, row


### PR DESCRIPTION
I am sorry I made mistakes during testing and thought that the Y rotation needed "compensation". In fact, all xyz rotations returned by the routine are correct and accurate. The YZX routine is clean and fine alone without further modification. Technically speaking the result is identical to the so-called full routine (matrix => quaternion => euler). I think this rotation matrix => euler is actually an elegant solution.