### PR TITLE
Removed direct usage of performance.now

### DIFF
--- a/src/image/image.ts
+++ b/src/image/image.ts
@@ -7,7 +7,7 @@ import * as fxImage from './imagefx';
 import type { Tensor } from '../tfjs/types';
 import type { Config } from '../config';
 import { env } from '../util/env';
-import { log } from '../util/util';
+import { log, now } from '../util/util';
 
 export type Input = Tensor | ImageData | ImageBitmap | HTMLImageElement | HTMLMediaElement | HTMLVideoElement | HTMLCanvasElement | OffscreenCanvas | typeof Image | typeof env.Canvas;
 
@@ -229,11 +229,11 @@ const checksum = async (input: Tensor): Promise<number> => { // use tf sum or js
     return sum0;
   };
   if (benchmarked === 0) {
-    const t0 = performance.now();
+    const t0 = now();
     await jsSum();
-    const t1 = performance.now();
+    const t1 = now();
     await tfSum();
-    const t2 = performance.now();
+    const t2 = now();
     benchmarked = t1 - t0 < t2 - t1 ? 1 : 2;
   }
   const res = benchmarked === 1 ? await jsSum() : await tfSum();

--- a/src/util/interpolate.ts
+++ b/src/util/interpolate.ts
@@ -8,11 +8,12 @@ import type { Config } from '../config';
 import * as moveNetCoords from '../body/movenetcoords';
 import * as blazePoseCoords from '../body/blazeposecoords';
 import * as efficientPoseCoords from '../body/efficientposecoords';
+import { now } from './util';
 
 const bufferedResult: Result = { face: [], body: [], hand: [], gesture: [], object: [], persons: [], performance: {}, timestamp: 0 };
 
 export function calc(newResult: Result, config: Config): Result {
-  const t0 = performance.now();
+  const t0 = now();
   if (!newResult) return { face: [], body: [], hand: [], gesture: [], object: [], persons: [], performance: {}, timestamp: 0 };
   // each record is only updated using deep clone when number of detected record changes, otherwise it will converge by itself
   // otherwise bufferedResult is a shallow clone of result plus updated local calculated values


### PR DESCRIPTION
Using `performance.now()` directly doesn't work in nodejs. I switched to using your utility function that works in both nodejs and browser environments.