### PR TITLE
fix(gear): ensure gear.modelPath is used for loadModel()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,12 @@ export interface FaceAntiSpoofConfig extends GenericConfig {}
 /** Liveness part of face configuration */
 export interface FaceLivenessConfig extends GenericConfig {}
 
+/** Gear part of face configuration */
+export interface FaceGearConfig extends GenericConfig {
+  /** minimum confidence for a detected race before results are discarded */
+  minConfidence: number,
+}
+
 /** Configures all face-specific options: face detection, mesh analysis, age, gender, emotion detection and face description */
 export interface FaceConfig extends GenericConfig {
   detector: Partial<FaceDetectorConfig>,
@@ -76,6 +82,7 @@ export interface FaceConfig extends GenericConfig {
   emotion: Partial<FaceEmotionConfig>,
   antispoof: Partial<FaceAntiSpoofConfig>,
   liveness: Partial<FaceLivenessConfig>,
+  gear: Partial<FaceGearConfig>,
 }
 
 /** Configures all body detection specific options */

--- a/src/gear/gear.ts
+++ b/src/gear/gear.ts
@@ -24,7 +24,7 @@ let skipped = Number.MAX_SAFE_INTEGER;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function load(config: Config) {
   if (env.initial) model = null;
-  if (!model) model = await loadModel(config.face['gear']);
+  if (!model) model = await loadModel(config.face['gear']?.modelPath);
   else if (config.debug) log('cached model:', model['modelUrl']);
   return model;
 }


### PR DESCRIPTION
With this usage should align correctly with how it's show in the unit test from 50a678c3.

On an unrelated note, the recent addition of `production=true` to the `.npmrc` will catch people off guard. Since every dependency is a dev dependency nothing will be installed on a clean clone unless you know to disable that production flag.