### PR TITLE
Add Node.js ESM compatibility (resolves #292)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "browser": "dist/human.esm.js",
   "types": "types/human.d.ts",
   "exports": {
+    "node": {
+      "require": "./dist/human.node.js",
+      "import": "./dist/human.node.js",
+      "module": "./dist/human.node.js"
+    },
     "require": "./dist/human.node.js",
     "import": "./dist/human.esm.js",
     "script": "./dist/human.js",


### PR DESCRIPTION
Currently, if you try to import Human into a pure Node.js ESM project, it fails (see #292)

This change points the Node.js module resolver to use the Node version instead of the ESM one