### PR TITLE
Fix build by restricting typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "rimraf": "^5.0.1",
     "tslib": "^2.6.2",
     "typedoc": "0.25.1",
-    "typescript": "^5.1.6"
+    "typescript": "5.1"
   }
 }


### PR DESCRIPTION
Closes #402 by using more specific typescript version (5.1 instead of ^5.1.6)